### PR TITLE
Update rhumsaa/uuid version reference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "rhumsaa/uuid": "2.7.3",
+        "rhumsaa/uuid": "^2.7.3",
         "predis/predis": "v1.0.0",
         "league/flysystem": "~0.5",
         "zendframework/zend-db": "~2.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "06c3608eb6d5c2e1cf65fbd38af2a584",
+    "hash": "3765dc038bd9f2035d8a02e7cc49e738",
     "packages": [
         {
             "name": "league/flysystem",
@@ -151,16 +151,16 @@
         },
         {
             "name": "rhumsaa/uuid",
-            "version": "2.7.3",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "b976326ca5977d7333f34e3c828ae7c22a49a65a"
+                "reference": "cca98c652cac412c9c2f109c69e5532f313435fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/b976326ca5977d7333f34e3c828ae7c22a49a65a",
-                "reference": "b976326ca5977d7333f34e3c828ae7c22a49a65a",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/cca98c652cac412c9c2f109c69e5532f313435fc",
+                "reference": "cca98c652cac412c9c2f109c69e5532f313435fc",
                 "shasum": ""
             },
             "require": {
@@ -184,7 +184,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7.x-dev"
+                    "dev-master": "2.8.x-dev"
                 }
             },
             "autoload": {
@@ -213,7 +213,7 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2014-08-27 22:39:41"
+            "time": "2014-11-09 18:42:56"
         },
         {
             "name": "zendframework/zend-db",


### PR DESCRIPTION
Noticed the hard version requirement of `2.7.3` caused a conflict in a project which uses `~2.8` of the same library.
The interface hasn't changed and the impact of updating is small anyway.

## Test
Run `$ phpunit` and watch all tests (still) pass